### PR TITLE
Improve observability of update mappings

### DIFF
--- a/src/main/java/ru/datana/integration/opc/component/ValueManager.java
+++ b/src/main/java/ru/datana/integration/opc/component/ValueManager.java
@@ -3,8 +3,10 @@ package ru.datana.integration.opc.component;
 import static java.time.Instant.now;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -31,15 +33,46 @@ public class ValueManager {
         public void registerMappings(String name, String env, Set<MappingDesc> descs) {
                 var key = buildKey(name, env);
                 if (descs == null || descs.isEmpty()) {
+                        log.debug("[{}@{}] reset mapping registry (empty mapping set)", name, env);
                         mappingKeys.remove(key);
                         return;
                 }
                 var map = mappingKeys.computeIfAbsent(key, k -> new HashMap<>());
                 map.clear();
+
+                List<String> updateKeys = new ArrayList<>();
+                List<String> plainKeys = new ArrayList<>();
+                List<String> missingKeys = new ArrayList<>();
+
                 descs.forEach(desc -> {
-                        var nodeId = Mapping.create(desc).getNodeId().getIdentifier().toString();
-                        map.put(nodeId, desc.getKey());
+                        var mapping = Mapping.create(desc);
+                        var nodeId = mapping.getNodeId().getIdentifier().toString();
+                        var mappingKey = desc.getKey();
+                        map.put(nodeId, mappingKey);
+                        if (mappingKey == null || mappingKey.isBlank()) {
+                                missingKeys.add(nodeId);
+                        } else if (mappingKey.endsWith(".Update")) {
+                                updateKeys.add(mappingKey);
+                        } else {
+                                plainKeys.add(mappingKey);
+                        }
                 });
+
+                log.debug("[{}@{}] registered {} mapping keys (update: {}, plain: {}, missing: {})", name, env, map.size(),
+                                updateKeys.size(), plainKeys.size(), missingKeys.size());
+
+                if (!missingKeys.isEmpty()) {
+                        log.warn("[{}@{}] mapping nodes without key: {}", name, env, missingKeys);
+                }
+
+                if (log.isTraceEnabled()) {
+                        if (!updateKeys.isEmpty()) {
+                                log.trace("[{}@{}] update-enabled keys: {}", name, env, updateKeys);
+                        }
+                        if (!plainKeys.isEmpty()) {
+                                log.trace("[{}@{}] plain keys without .Update suffix: {}", name, env, plainKeys);
+                        }
+                }
         }
 
         public void setValue(String name, String env, String id, TagValue value) {
@@ -47,6 +80,7 @@ public class ValueManager {
                 var key = buildKey(name, env);
                 var valueMap = mappings.get(key);
                 if (valueMap == null) {
+                        log.debug("[{}@{}] init value cache", name, env);
                         valueMap = new HashMap<>();
                         mappings.put(key, valueMap);
                 }
@@ -56,8 +90,13 @@ public class ValueManager {
                 if (keyMap != null) {
                         var mappingKey = keyMap.get(id);
                         if (mappingKey != null) {
+                                log.debug("[{}@{}] resolved mapping key [{}] for node [{}]", name, env, mappingKey, id);
                                 controllerUpdateService.handleValueChange(name, env, mappingKey, previous, value);
+                        } else {
+                                log.debug("[{}@{}] no mapping key for node [{}]", name, env, id);
                         }
+                } else {
+                        log.debug("[{}@{}] no registered mapping keys", name, env);
                 }
         }
 

--- a/src/main/java/ru/datana/integration/opc/service/ControllerUpdateService.java
+++ b/src/main/java/ru/datana/integration/opc/service/ControllerUpdateService.java
@@ -18,7 +18,12 @@ public class ControllerUpdateService {
         private final ControllerApiClient client;
 
         public void handleValueChange(String controllerId, String env, String mappingKey, TagValue previous, TagValue current) {
-                if (mappingKey == null || !mappingKey.endsWith(UPDATE_SUFFIX)) {
+                if (mappingKey == null) {
+                        log.debug("Skip [{}@{}] update without mapping key", controllerId, env);
+                        return;
+                }
+                if (!mappingKey.endsWith(UPDATE_SUFFIX)) {
+                        log.debug("Skip [{}@{}:{}] update without suffix", controllerId, env, mappingKey);
                         return;
                 }
                 var currentValue = current == null ? null : current.getValue();
@@ -28,12 +33,16 @@ public class ControllerUpdateService {
                 }
                 var previousValue = previous == null ? null : previous.getValue();
                 if (previousValue != null && Objects.equals(previousValue, currentValue)) {
+                        log.debug("Skip [{}@{}:{}] unchanged value {}", controllerId, env, mappingKey, currentValue);
                         return;
                 }
 
+                log.debug("Handle [{}@{}:{}] update prev={} current={}", controllerId, env, mappingKey, previousValue,
+                                currentValue);
                 var keyWithoutSuffix = mappingKey.substring(0, mappingKey.length() - UPDATE_SUFFIX.length());
                 var parts = keyWithoutSuffix.split("\\.");
                 if (parts.length == 0) {
+                        log.debug("Skip [{}@{}:{}] empty mapping key", controllerId, env, mappingKey);
                         return;
                 }
 
@@ -48,6 +57,7 @@ public class ControllerUpdateService {
 
         private void handleControllerCommand(String controllerId, String env, String command, Double value) {
                 int numericValue = value.intValue();
+                log.debug("Execute controller command [{}] with value {} for {}@{}", command, value, controllerId, env);
                 switch (command) {
                 case "State" -> {
                         switch (numericValue) {
@@ -65,7 +75,11 @@ public class ControllerUpdateService {
                 }
         }
 
+        private static final String SUPPORTED_VARIABLE_PROPERTIES =
+                        "state, limit_bottom, limit_top, set_point, coef_line_opt, coef_quad_opt, target";
+
         private void handleVariableUpdate(String controllerId, String env, String variable, String property, Double value) {
+                log.debug("Execute variable update [{}].[{}] = {} for {}@{}", variable, property, value, controllerId, env);
                 switch (property) {
                 case "state" -> {
                         var stateValue = value.intValue() == 0 ? "OFF" : "ON";
@@ -78,7 +92,8 @@ public class ControllerUpdateService {
                         client.updateOptimization(env, controllerId,
                                         singletonMap("vars", singletonMap(variable, singletonMap(property, value))));
                 }
-                default -> log.debug("Unsupported property [{}] for variable [{}]", property, variable);
+                default -> log.warn("Skip [{}@{}:{}] unsupported property [{}]; supported properties: {}", controllerId, env,
+                                variable, property, SUPPORTED_VARIABLE_PROPERTIES);
                 }
         }
 


### PR DESCRIPTION
## Summary
- log mapping registration totals and list update-vs-plain keys to highlight missing .Update bindings
- warn about mapping descriptions without keys and expose supported variable property names when updates are skipped

## Testing
- mvn -B -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e4de2a34c08321bae68b5cb901bd69