### PR TITLE
Make OPC subscription flow asynchronous

### DIFF
--- a/src/main/java/ru/datana/integration/opc/component/ValueManager.java
+++ b/src/main/java/ru/datana/integration/opc/component/ValueManager.java
@@ -8,6 +8,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
@@ -27,6 +29,8 @@ public class ValueManager {
         private final Map<String, Map<String, String>> mappingKeys = new HashMap<>();
         private final Map<String, Instant> updateMap = new HashMap<>();
         private final ControllerUpdateService controllerUpdateService;
+        @Qualifier("controllerUpdateTaskExecutor")
+        private final TaskExecutor controllerUpdateTaskExecutor;
 
         public void registerMappings(String name, String env, Set<MappingDesc> descs) {
                 var key = buildKey(name, env);
@@ -58,7 +62,8 @@ public class ValueManager {
                         var mappingKey = keyMap.get(id);
                         if (mappingKey != null) {
                                 log.debug("[{}@{}] resolved mapping key [{}] for node [{}]", name, env, mappingKey, id);
-                                controllerUpdateService.handleValueChange(name, env, mappingKey, previous, value);
+                                controllerUpdateTaskExecutor.execute(() -> controllerUpdateService.handleValueChange(name, env,
+                                                mappingKey, previous, value));
                         } else {
                                 log.debug("[{}@{}] no mapping key for node [{}]", name, env, id);
                         }

--- a/src/main/java/ru/datana/integration/opc/config/AsyncConfiguration.java
+++ b/src/main/java/ru/datana/integration/opc/config/AsyncConfiguration.java
@@ -1,0 +1,32 @@
+package ru.datana.integration.opc.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class AsyncConfiguration {
+
+        @Bean(name = "subscriptionTaskExecutor")
+        public TaskExecutor subscriptionTaskExecutor() {
+                var executor = new ThreadPoolTaskExecutor();
+                executor.setThreadNamePrefix("subscription-");
+                executor.setCorePoolSize(2);
+                executor.setMaxPoolSize(8);
+                executor.setQueueCapacity(100);
+                executor.initialize();
+                return executor;
+        }
+
+        @Bean(name = "controllerUpdateTaskExecutor")
+        public TaskExecutor controllerUpdateTaskExecutor() {
+                var executor = new ThreadPoolTaskExecutor();
+                executor.setThreadNamePrefix("controller-update-");
+                executor.setCorePoolSize(4);
+                executor.setMaxPoolSize(16);
+                executor.setQueueCapacity(200);
+                executor.initialize();
+                return executor;
+        }
+}


### PR DESCRIPTION
## Summary
- add dedicated task executors for OPC subscription processing and controller updates
- run OPC subscription creation in the background to avoid blocking the /subscribe handler
- dispatch controller update callbacks asynchronously via the new executor

## Testing
- `mvn -DskipTests package`


------
https://chatgpt.com/codex/tasks/task_e_68e51d7c8ad483218e0d82de5901bf84