### PR TITLE
Skip initial subscription values when forwarding updates

### DIFF
--- a/src/main/java/ru/datana/integration/opc/component/ValueManager.java
+++ b/src/main/java/ru/datana/integration/opc/component/ValueManager.java
@@ -62,6 +62,10 @@ public class ValueManager {
                         var mappingKey = keyMap.get(id);
                         if (mappingKey != null) {
                                 log.debug("[{}@{}] resolved mapping key [{}] for node [{}]", name, env, mappingKey, id);
+                                if (previous == null) {
+                                        log.debug("[{}@{}:{}] skip initial value", name, env, mappingKey);
+                                        return;
+                                }
                                 controllerUpdateTaskExecutor.execute(() -> controllerUpdateService.handleValueChange(name, env,
                                                 mappingKey, previous, value));
                         } else {


### PR DESCRIPTION
## Summary
- avoid scheduling controller updates for the initial value received after a subscription is created

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e524440dec83219cbac3811bed4487