### PR TITLE
Handle namespace changes on OPC reconnect

### DIFF
--- a/src/main/java/ru/datana/integration/opc/dto/Mapping.java
+++ b/src/main/java/ru/datana/integration/opc/dto/Mapping.java
@@ -19,20 +19,23 @@ import ru.datana.integration.opc.request.MappingDesc;
 @AllArgsConstructor(access = PRIVATE)
 public class Mapping {
 	public static Mapping create(MappingDesc desc) {
-		return Mapping.builder().key(desc.getKey()).namespaceIndex(desc.getNamespaceIndex()).nodeId(buildNodeId(desc))
-				.build();
+		return create(desc, desc.getNamespaceIndex());
 	}
 
-	private static NodeId buildNodeId(MappingDesc desc) {
-		int nsIdx = desc.getNamespaceIndex();
+	public static Mapping create(MappingDesc desc, int namespaceIndex) {
+		return Mapping.builder().key(desc.getKey()).namespaceIndex(namespaceIndex)
+				.nodeId(buildNodeId(desc, namespaceIndex)).build();
+	}
+
+	private static NodeId buildNodeId(MappingDesc desc, int namespaceIndex) {
 		if (desc.getNodeId() != null) {
-			return new NodeId(nsIdx, desc.getNodeId());
+			return new NodeId(namespaceIndex, desc.getNodeId());
 		} else if (desc.getTag() != null) {
-			return new NodeId(nsIdx, "%s.%s".formatted(desc.getTag(), desc.getAttribute()));
+			return new NodeId(namespaceIndex, "%s.%s".formatted(desc.getTag(), desc.getAttribute()));
 		} else if (desc.getUuid() != null) {
-			return new NodeId(nsIdx, desc.getUuid());
+			return new NodeId(namespaceIndex, desc.getUuid());
 		} else if (desc.getBytes() != null) {
-			return new NodeId(nsIdx, of(desc.getBytes().getBytes()));
+			return new NodeId(namespaceIndex, of(desc.getBytes().getBytes()));
 		} else {
 			throw new SubscriptionException(Set.of(new SubscriptionException.ErrorDescription("MAPPING", desc.getKey(), "Validation error: all {nodeId, tag, uuid, bytes} are empty")));
 		}


### PR DESCRIPTION
## Summary
- cache namespace URIs per environment to resolve the current namespace index before subscribing, reading, or writing tags
- clear cached namespace mappings whenever a client reconnects and allow mappings to be rebuilt with the resolved namespace index

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e648d208748321ab980417cbb4086e