### PR TITLE
Adjust controller state mappings to avoid zero

### DIFF
--- a/src/main/java/ru/datana/integration/opc/service/ControllerUpdateService.java
+++ b/src/main/java/ru/datana/integration/opc/service/ControllerUpdateService.java
@@ -61,15 +61,19 @@ public class ControllerUpdateService {
                 switch (command) {
                 case "State" -> {
                         switch (numericValue) {
-                        case 0 -> client.stop(env, controllerId);
-                        case 1 -> client.startPredict(env, controllerId);
-                        case 2 -> client.start(env, controllerId);
+                        case 1 -> client.stop(env, controllerId);
+                        case 2 -> client.startPredict(env, controllerId);
+                        case 3 -> client.start(env, controllerId);
                         default -> log.warn("Unknown controller state value [{}] for {}@{}", numericValue, controllerId, env);
                         }
                 }
                 case "OptimizationState" -> {
-                        var enabled = numericValue != 0;
-                        client.updateOptimization(env, controllerId, singletonMap("enabled", enabled));
+                        var enabled = numericValue == 2;
+                        if (numericValue == 1 || numericValue == 2) {
+                                client.updateOptimization(env, controllerId, singletonMap("enabled", enabled));
+                        } else {
+                                log.warn("Unknown optimization state value [{}] for {}@{}", numericValue, controllerId, env);
+                        }
                 }
                 default -> log.debug("Unsupported controller command [{}]", command);
                 }
@@ -79,8 +83,14 @@ public class ControllerUpdateService {
                 log.debug("Execute variable update [{}].[{}] = {} for {}@{}", variable, property, value, controllerId, env);
                 switch (property) {
                 case "state" -> {
-                        var stateValue = value.intValue() == 0 ? "OFF" : "ON";
-                        client.updateStates(env, controllerId, singletonMap(variable, stateValue));
+                        var numericValue = value.intValue();
+                        if (numericValue == 1 || numericValue == 2) {
+                                var stateValue = numericValue == 1 ? "OFF" : "ON";
+                                client.updateStates(env, controllerId, singletonMap(variable, stateValue));
+                        } else {
+                                log.warn("Unknown state value [{}] for variable [{}] of {}@{}", numericValue, variable, controllerId,
+                                                env);
+                        }
                 }
                 case "limit_bottom", "limit_top", "set_point" -> {
                         client.updateLimits(env, controllerId, singletonMap(variable, singletonMap(property, value)));

--- a/src/test/java/ru/datana/integration/opc/service/ControllerUpdateServiceTest.java
+++ b/src/test/java/ru/datana/integration/opc/service/ControllerUpdateServiceTest.java
@@ -1,0 +1,87 @@
+package ru.datana.integration.opc.service;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import ru.datana.integration.opc.dto.TagValue;
+
+@ExtendWith(MockitoExtension.class)
+class ControllerUpdateServiceTest {
+
+    private static final String CONTROLLER_ID = "controller";
+    private static final String ENV = "env";
+
+    @Mock
+    private ControllerApiClient client;
+
+    @InjectMocks
+    private ControllerUpdateService service;
+
+    @Test
+    void stateCommandOneStopsController() {
+        service.handleValueChange(CONTROLLER_ID, ENV, "State.Update", null, tagValue(1));
+
+        verify(client).stop(ENV, CONTROLLER_ID);
+        verifyNoMoreInteractions(client);
+    }
+
+    @Test
+    void stateCommandTwoStartsPredict() {
+        service.handleValueChange(CONTROLLER_ID, ENV, "State.Update", null, tagValue(2));
+
+        verify(client).startPredict(ENV, CONTROLLER_ID);
+        verifyNoMoreInteractions(client);
+    }
+
+    @Test
+    void stateCommandThreeStartsController() {
+        service.handleValueChange(CONTROLLER_ID, ENV, "State.Update", null, tagValue(3));
+
+        verify(client).start(ENV, CONTROLLER_ID);
+        verifyNoMoreInteractions(client);
+    }
+
+    @Test
+    void optimizationStateOneDisablesOptimization() {
+        service.handleValueChange(CONTROLLER_ID, ENV, "OptimizationState.Update", null, tagValue(1));
+
+        verify(client).updateOptimization(ENV, CONTROLLER_ID, Map.of("enabled", false));
+        verifyNoMoreInteractions(client);
+    }
+
+    @Test
+    void optimizationStateTwoEnablesOptimization() {
+        service.handleValueChange(CONTROLLER_ID, ENV, "OptimizationState.Update", null, tagValue(2));
+
+        verify(client).updateOptimization(ENV, CONTROLLER_ID, Map.of("enabled", true));
+        verifyNoMoreInteractions(client);
+    }
+
+    @Test
+    void variableStateOneSendsOffValue() {
+        service.handleValueChange(CONTROLLER_ID, ENV, "Pump.state.Update", null, tagValue(1));
+
+        verify(client).updateStates(ENV, CONTROLLER_ID, Map.of("Pump", "OFF"));
+        verifyNoMoreInteractions(client);
+    }
+
+    @Test
+    void variableStateTwoSendsOnValue() {
+        service.handleValueChange(CONTROLLER_ID, ENV, "Pump.state.Update", null, tagValue(2));
+
+        verify(client).updateStates(ENV, CONTROLLER_ID, Map.of("Pump", "ON"));
+        verifyNoMoreInteractions(client);
+    }
+
+    private static TagValue tagValue(double value) {
+        return TagValue.builder().value(value).build();
+    }
+}


### PR DESCRIPTION
## Summary
- shift controller state commands to use values 1-3 and guard invalid optimization and variable state updates
- map variable state and optimization toggles to new 1/2 encoding and log unexpected values
- add unit tests covering the updated controller command and variable state handling

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68e66542fe6483219ee7471f3bf9efdd